### PR TITLE
don't require the user to install dependencies manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: node_js
 node_js:
   - "0.11"
   - "0.10"
-before_install: npm install -g grunt-cli
-install: npm install

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ prequest({
 To use the other methods: [delete, patch, head], specify it in method.
 
 ## Testing
-Install [mocha](http://visionmedia.github.io/mocha/) and [grunt](http://gruntjs.com/).
-
-    $ npm install -g mocha
-    $ npm install -g grunt-cli
 
 To run the tests:
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "^4.8.8",
     "grunt": "^0.4.5",
     "grunt-cafe-mocha": "^0.1.12",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-express-server": "^0.4.19",
     "mocha": "^1.21.4"


### PR DESCRIPTION
the local dependency of mocha and grunt-cli is used.

dependencies with a binary are put into the $PATH when run from npm run scripts, you can you just call them as it would have been a global. that's what we're now doing with grunt-cli.

also don't need the travis install thingy anymore.
