### PR TITLE
When response is >= 400, reject with an error object and not the response

### DIFF
--- a/test/prequestTests.js
+++ b/test/prequestTests.js
@@ -36,8 +36,25 @@ describe('Prequest GET tests', function () {
   it('should fail with unknown route', function (done) {
     prequest(url + '/unknown')
       .catch(function (err) {
+        assert(err instanceof Error, 'Err must be an actual error');
+        assert(err.message.indexOf('404') !== -1,
+          'Error message must include status');
+        assert(err.message.indexOf('Cannot GET') !== -1,
+          'Error message must include part of the response body');
+        assert(err.response.headers !== null,
+          'Error object must include the bad response');
         assert.equal(err.statusCode, 404, 'Unsuccessful Get');
         assert.strictEqual(err.body.trimRight(), 'Cannot GET /unknown');
+        done();
+      });
+  });
+
+
+  it('should fail with conn refused', function (done) {
+    prequest('http://nosuchserver')
+      .catch(function (err) {
+        assert(err instanceof Error, 'Err must be an actual error');
+        assert.equal(err.code, 'ENOTFOUND', 'No such server');
         done();
       });
   });


### PR DESCRIPTION
Hi! I'm following the Bluebird advice here:

http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error

When an HTTP status >= 400 is received, prequest currently rejects with the response, which is not an Error object. So console.log(err) ends up logging the (quite large) response object, and no stack (at least on node 0.10.x).

In this PR I've changed it to a proper `HttpError` object which has a `.statusCode`, `.body`, and `.response` properties.
